### PR TITLE
hal: Remove ndk_platform backend. Use the ndk backend.

### DIFF
--- a/hal/Android.mk
+++ b/hal/Android.mk
@@ -368,7 +368,7 @@ endif
 
 LOCAL_SHARED_LIBRARIES += libbase libhidlbase libutils android.hardware.power@1.2 liblog
 
-LOCAL_SHARED_LIBRARIES += android.hardware.power-V1-ndk_platform
+LOCAL_SHARED_LIBRARIES += android.hardware.power-V1-ndk
 LOCAL_SHARED_LIBRARIES += libbinder_ndk
 
 LOCAL_SRC_FILES += audio_perf.cpp


### PR DESCRIPTION
The ndk_platform backend will soon be deprecated because the ndk backend can serve the same purpose. This is to eliminate the confusion about having two variants (ndk and ndk_platform) for the same ndk backend.

Bug: 161456198
Test: m
Merged-In: I14a1c57bd06f1f2aa52491f779c7030d4de03547
Change-Id: I14a1c57bd06f1f2aa52491f779c7030d4de03547